### PR TITLE
Fix configuration error in 'UploadCanvasMessage' when a valid file passed

### DIFF
--- a/Apps.Braze/Actions/CanvasActions.cs
+++ b/Apps.Braze/Actions/CanvasActions.cs
@@ -73,7 +73,7 @@ namespace Apps.Braze.Actions
         {
             var file = await fileManagementClient.DownloadAsync(input.File);
             var fileContent = Encoding.UTF8.GetString(await file.GetByteData());
-            var fileExtension = Path.GetExtension(fileContent);
+            var fileExtension = Path.GetExtension(input.File.Name);
 
             var converter = ConverterFactory<CanvasMessageIdentifier>.CreateConverter(fileExtension, fileManagementClient);
             var (identifier, translationMap) = converter.FromFile(fileContent);

--- a/Apps.Braze/Apps.Braze.csproj
+++ b/Apps.Braze/Apps.Braze.csproj
@@ -6,7 +6,7 @@
         <Nullable>enable</Nullable>
         <Product>Braze [Beta]</Product>
         <Description>Braze is a customer engagement platform that helps brands deliver personalized, real-time messaging across channels like email, mobile, SMS, and web.</Description>
-        <Version>1.0.10</Version>
+        <Version>1.0.11</Version>
         <AssemblyName>Apps.Braze</AssemblyName>
     </PropertyGroup>
 


### PR DESCRIPTION
Resolved an issue where valid files triggered a "The file format is not supported" error during uploads via the "Upload canvas message" action.
